### PR TITLE
Add Docker image for Polymer projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM inclusivedesign/nodejs
+
+# Install development dependencies
+RUN yarn global add bower gulp-cli polymer-cli
+
+# The application repository should be mounted here (e.g. "-v ${PWD}:/app")
+RUN mkdir /app
+WORKDIR /app
+
+# We may expose a port if `polymer serve` is used
+EXPOSE 8080
+
+# Helper script
+COPY build.sh /usr/bin

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 IDI Ops
+Copyright (c) 2016 OCAD University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or you can run each command in steps:
     $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer bower install
     $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer polymer build
 
-And your project will be available in the 'build' directory.
+And your project will be available in the 'build' directory in the standard bundled/unbundled structure produced by a Polymer [https://github.com/PolymerElements/polymer-starter-kit#build](build).
 
 You can also add it as a shell alias to avoid having to type it every time:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # docker-polymer
-Docker image with all necessary tools for Polymer development
+
+Docker image with all necessary tools for Polymer development.
+
+The application code should be mounted under /app inside the container.
+
+# Building a Polymer project
+
+This command will run `yarn install; bower install; polymer build`:
+
+    $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer build.sh
+
+Or you can run each command in steps:
+
+    $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer yarn install
+    $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer bower install
+    $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer polymer build
+
+And your project will be available in the 'build' directory.
+
+You can also add it as a shell alias to avoid having to type it every time:
+
+    $ alias polymer-build='docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer build.sh'
+    $ polymer-build
+
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or you can run each command in steps:
     $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer bower install
     $ docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer polymer build
 
-And your project will be available in the 'build' directory in the standard bundled/unbundled structure produced by a Polymer [https://github.com/PolymerElements/polymer-starter-kit#build](build).
+And your project will be available in the 'build' directory in the standard bundled/unbundled structure produced by a Polymer [build](https://github.com/PolymerElements/polymer-starter-kit#build).
 
 You can also add it as a shell alias to avoid having to type it every time:
 

--- a/README.md
+++ b/README.md
@@ -23,4 +23,34 @@ You can also add it as a shell alias to avoid having to type it every time:
     $ alias polymer-build='docker run --rm -ti -v ${PWD}:/app inclusivedesign/polymer build.sh'
     $ polymer-build
 
+# Live development
 
+In order to edit your code and see the changes in real-time, you can use `polymer serve` in the same way:
+
+    $ docker run --rm -ti -v ${PWD}:/app -p 8080:8080 inclusivedesign/polymer polymer serve -H 0.0.0.0
+
+The `-H 0.0.0.0` is necessary so Polymer doesn't listen on `localhost`, which could cause some issues with Docker networking. Polymer will listen by default on port 8080 which, in this example, is also mapped to port 8080 on your host.
+
+You do not need to be inside the container to edit the code. `polymer serve` will pick up the changes you make through the Docker volume (`-v ${PWD}:/app`) and update automatically.
+
+# Deployment using Docker
+
+Once the project is successfully built, you can create a Docker image that will serve the build artifacts.
+
+For example, create a Dockerfile with the following contents and put it in your project's parent folder:
+
+```
+FROM inclusivedesign/nginx
+
+COPY build/unbundled /usr/share/nginx/html
+```
+
+Now build the Docker image:
+
+    $ docker build -t my-project-image .
+
+The image `my-project-image` can now be used to serve the contents of your project:
+
+    $ docker run -d --name my-project -p 8000:80 my-project-image
+
+Your project will be accesible on http://localhost:8000

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd /app
+
+yarn install
+bower --allow-root install
+polymer build


### PR DESCRIPTION
The goal is to have a container image that has all dependencies required to develop Polymer projects, without having to install them on the development machine or CI nodes.

The image does not have a default entrypoint to give the developer more flexibility in which commands should run. However, it ships a build.sh script that runs the build steps for standard Polymer projects.

The output of a Polymer project is usually a static website (HTML/JS/CSS/images), which will be available in the 'build' directory. This output can be used to build a final container image (probably based on the `inclusivedesign/nginx` image), that is, this Polymer image is only used for building/developing projects and it's not the image that will be deployed.

@avtar @waharnum @amatas, could review this PR?